### PR TITLE
Warnings with ruby 1.9.2-p290

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -24,11 +24,11 @@ Simple, feature rich ASCII table generator.
    
   puts table(['a', 'b'], [1, 2], [3, 4], :separator, [4, 6])
    
-  t = table ['a', 'b']
-  t << [1, 2]
-  t << [3, 4]
-  t.add_separator
-  t << [4, 6]
+  v = table ['a', 'b']
+  v << [1, 2]
+  v << [3, 4]
+  v.add_separator
+  v << [4, 6]
   puts t
    
   user_table = table do |t|

--- a/examples/examples.rb
+++ b/examples/examples.rb
@@ -14,11 +14,11 @@ t << [4, 6]
 puts t
 
 puts
-user_table = table do |t|
-  t.headings = 'First Name', 'Last Name', 'Email'
-  t << %w( TJ Holowaychuk tj@vision-media.ca )
-  t << %w( Bob Someone bob@vision-media.ca )
-  t << %w( Joe Whatever bob@vision-media.ca )
+user_table = table do |v|
+  v.headings = 'First Name', 'Last Name', 'Email'
+  v << %w( TJ Holowaychuk tj@vision-media.ca )
+  v << %w( Bob Someone bob@vision-media.ca )
+  v << %w( Joe Whatever bob@vision-media.ca )
 end
 puts user_table
 

--- a/lib/terminal-table/core_ext.rb
+++ b/lib/terminal-table/core_ext.rb
@@ -22,7 +22,7 @@ class Object
     if block.arity > 0
       yield self
     else
-      self.instance_eval &block
+      self.instance_eval(&block)
     end
   end
 end

--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -21,7 +21,7 @@ module Terminal
     ##
     # Rows array.
     
-    attr_accessor :rows
+    attr_writer :rows
     
     ##
     # Generates a ASCII table with the given _options_.
@@ -29,7 +29,7 @@ module Terminal
     def initialize options = {}, &block
       @headings = options.fetch :headings, []
       @rows = options.fetch :rows, []
-      yield_or_eval &block if block
+      yield_or_eval(&block) if block
     end
     
     ##


### PR DESCRIPTION
When I execute terminal-table with warnings option enabled, we get several warnings :
- `Warning: shadowing outer local variable - t` : On example file, i think that it's better to change the name variable t by v or other to avoid a confusion on the scopes.

``` ruby
user_table = table do |v|
  v.headings = 'First Name', 'Last Name', 'Email'
  v << %w( TJ Holowaychuk tj@vision-media.ca )
  v << %w( Bob Someone bob@vision-media.ca )
  v << %w( Joe Whatever bob@vision-media.ca )
end
```
- `~/.rvm/gems/ruby-1.9.2-p290@CalculationTools/gems/terminal-table-1.4.2/lib/terminal-table/core_ext.rb:25: warning: '&' interpreted as argument prefix` : The only way that I found to solve this problem, is to add parentheses on '&block' to avoid confusion.

``` ruby
class Object
  def yield_or_eval &block
    return unless block
    if block.arity > 0
      yield self
    else
      self.instance_eval(&block)
    end
  end
end
```
- `~/.rvm/gems/ruby-1.9.2-p290@CalculationTools/gems/terminal-table-1.4.2/lib/terminal-table/table.rb:32: warning:`&' interpreted as argument prefix` : idem

``` ruby
def initialize options = {}, &block
  @headings = options.fetch :headings, []
  @rows = options.fetch :rows, []
  yield_or_eval(&block) if block
end
```
- `~/.rvm/gems/ruby-1.9.2-p290@CalculationTools/gems/terminal-table-1.4.2/lib/terminal-table/table.rb:270: warning: method redefined; discarding old rows` : Rows is defined as instance variable with attr_accessor but the reader method is redefined manually line 270 so it's necessary to remove one.

``` ruby
attr_writer :rows
```

Otherwise, it's a great tool, thanks lot.
