### PR TITLE
Add support for multi-row headings

### DIFF
--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -96,9 +96,13 @@ module Terminal
     ##
     # Set the headings
     
-    def headings= array
-      @headings = Row.new(self, array)
-      recalc_column_widths @headings
+    def headings= arrays
+      arrays = [arrays] unless arrays.first.is_a?(Array)
+      @headings = arrays.map do |array|
+        row = Row.new(self, array)
+        recalc_column_widths row
+        row
+      end
     end
 
     ##
@@ -111,9 +115,11 @@ module Terminal
         buffer << Row.new(self, [title_cell_options])
         buffer << separator
       end
-      unless @headings.cells.empty?
-        buffer << @headings
-        buffer << separator
+      @headings.each do |row|
+        unless row.cells.empty?
+          buffer << row
+          buffer << separator
+        end
       end
       buffer += @rows
       buffer << separator
@@ -201,7 +207,7 @@ module Terminal
     # Return headings combined with rows.
     
     def headings_with_rows
-      [@headings] + rows
+      @headings + rows
     end
     
     def yield_or_eval &block

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -283,6 +283,24 @@ module Terminal
       EOF
     end
 
+    it "should render multi-row headings properly" do
+      @table.headings = [['Char', 'Num'], [{ :value => "2nd heading", :colspan => 2 }]]
+      @table << ['a', 1]
+      @table << ['b', 2]
+      @table << ['c', 3]
+      @table.render.should == <<-EOF.deindent
+        +------+------+
+        | Char | Num  |
+        +------+------+
+        | 2nd heading |
+        +------+------+
+        | a    | 1    |
+        | b    | 2    |
+        | c    | 3    |
+        +------+------+
+      EOF
+    end
+
     it "should allows a hash of options for creation" do
       headings = ['Char', 'Num']
       rows = [['a', 1], ['b', 2], ['c', 3]]


### PR DESCRIPTION
Horizontal space is limited in consoles and I needed several groups of related columns. In order to save space, I added support for multi-row headings and used this in conjunction with colspan. It works very well.

```
+------+------+
| Char | Num  |
+------+------+
| 2nd heading |
+------+------+
| a    | 1    |
| b    | 2    |
| c    | 3    |
+------+------+
```

I also had some trouble running the specs so I fixed that as well as a problem with the gemspec.