### PR TITLE
Remove unused attr_reader definition of cell width

### DIFF
--- a/lib/terminal-table/cell.rb
+++ b/lib/terminal-table/cell.rb
@@ -2,12 +2,6 @@
 module Terminal
   class Table
     class Cell
-      
-      ##
-      # Cell width.
-      
-      attr_reader :width
-      
       ##
       # Cell value.
       


### PR DESCRIPTION
Hi. `width` used to be defined twice in `Teminal::Table::Cell`, and since the second definition overwrote the first definition (`attr_reader :width`), the first definition was never actually used and just triggered a warning when running in verbose mode:
  `~/.gem/ruby/2.0.0/gems/terminal-table-1.4.5/lib/terminal-table/cell.rb:77: warning: method redefined; discarding old width`