### PR TITLE
Fix misleading "undefined local variable or method 'wanted'" error

### DIFF
--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -166,7 +166,7 @@ module Terminal
       return [] if style.width.nil?
       spacing = style.width - columns_width
       if spacing < 0
-        raise "Table width exceeds wanted width of #{wanted} characters."
+        raise "Table width exceeds wanted width of #{style.width} characters."
       else
         per_col = spacing / number_of_columns
         arr = (1...number_of_columns).to_a.map { |i| per_col }


### PR DESCRIPTION
There is a misleading error message when row width exceeds style width.

irb> Terminal::Table.new(:rows => [['foo']],:style => {:width => 2})
NameError: undefined local variable or method `wanted' for #Terminal::Table:0x00000001f93b60

Replaced wanted with style.width
