### PR TITLE
Fix undefined var when row exceeded table width

### DIFF
--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -1,4 +1,3 @@
-
 module Terminal
   class Table
     
@@ -166,7 +165,7 @@ module Terminal
       return [] if style.width.nil?
       spacing = style.width - columns_width
       if spacing < 0
-        raise "Table width exceeds wanted width of #{wanted} characters."
+        raise "Table width exceeds wanted width of #{style.width} characters."
       else
         per_col = spacing / number_of_columns
         arr = (1...number_of_columns).to_a.map { |i| per_col }


### PR DESCRIPTION
If row width exceeded wanted table width an exception was thrown, but tried to use an non existing variable. Using style.width now instead.