### PR TITLE
add support for cjk character

### DIFF
--- a/lib/terminal-table/cell.rb
+++ b/lib/terminal-table/cell.rb
@@ -4,35 +4,35 @@ module Terminal
     class Cell
       ##
       # Cell value.
-      
+
       attr_reader :value
-      
+
       ##
       # Column span.
-      
+
       attr_reader :colspan
-      
+
       ##
       # Initialize with _options_.
-      
+
       def initialize options = nil
         @value, options = options, {} unless Hash === options
         @value = options.fetch :value, value
         @alignment = options.fetch :alignment, nil
         @colspan = options.fetch :colspan, 1
-        @width = options.fetch :width, @value.to_s.size
+        @width = options.fetch :width, @value.to_s.width
         @index = options.fetch :index
         @table = options.fetch :table
       end
-      
+
       def alignment?
         !@alignment.nil?
       end
-      
+
       def alignment
         @alignment || @table.style.alignment || :left
       end
-      
+
       def alignment=(val)
         supported = %w(left center right)
         if supported.include?(val.to_s)
@@ -41,7 +41,7 @@ module Terminal
           raise "Aligment must be one of: #{supported.join(' ')}"
         end
       end
-      
+
       def align(val, position, length)
         positions = { :left => :ljust, :right => :rjust, :center => :center }
         val.public_send(positions[position], length)
@@ -49,29 +49,29 @@ module Terminal
       def lines
         @value.to_s.split(/\n/)
       end
-      
+
       ##
       # Render the cell.
-      
+
       def render(line = 0)
         left = " " * @table.style.padding_left
         right = " " * @table.style.padding_right
-        render_width = lines[line].to_s.size - escape(lines[line]).size + width
-        align("#{left}#{lines[line]}#{right}", alignment, render_width + @table.cell_padding)
+        render_width = lines[line].to_s.width - escape(lines[line]).width + width
+        "#{left}#{lines[line]}#{right}".align(alignment, render_width + @table.cell_padding)
       end
       alias :to_s :render
-      
+
       ##
       # Returns the longest line in the cell and
       # removes all ANSI escape sequences (e.g. color)
-      
+
       def value_for_column_width_recalc
-        lines.map{ |s| escape(s) }.max_by{ |s| s.size }
+        lines.map{ |s| escape(s) }.max_by{ |s| s.width }
       end
-      
+
       ##
       # Returns the width of this cell
-      
+
       def width
         padding = (colspan - 1) * @table.cell_spacing
         inner_width = (1..@colspan).to_a.inject(0) do |w, counter|
@@ -81,7 +81,7 @@ module Terminal
       end
 
       ##
-      # removes all ANSI escape sequences (e.g. color)      
+      # removes all ANSI escape sequences (e.g. color)
       def escape(line)
         line.to_s.gsub(/\x1b(\[|\(|\))[;?0-9]*[0-9A-Za-z]/, '').
           gsub(/\x1b(\[|\(|\))[;?0-9]*[0-9A-Za-z]/, '').

--- a/lib/terminal-table/core_ext.rb
+++ b/lib/terminal-table/core_ext.rb
@@ -1,0 +1,17 @@
+
+class String
+  def align position, length
+    self.__send__ position, length - cjks.size
+  end
+  alias_method :left, :ljust
+  alias_method :right, :rjust
+
+  def cjks
+    self.scan /\p{Han}|\p{Katakana}|\p{Hiragana}\p{Hangul}/
+  end
+
+  def width
+    size + cjks.size
+  end
+
+end

--- a/lib/terminal-table/core_ext.rb
+++ b/lib/terminal-table/core_ext.rb
@@ -1,14 +1,38 @@
 
 class String
+  class String
+  CJKC_RANGES = [
+    #20941 CJK Unified Ideographs block.
+    (0x4E00..0x9FCC),
+    #6582 characters from the CJKUI Ext A block
+    (0x3400..0x4DB5),
+    #full width symbols
+    (0xFF01..0xFF5E),
+    (0xFFE0..0xFFEE),
+    #42711 characters from the CJKUI Ext B block.
+    (0x21600..0x2A6DF),
+    #4149 characters from the CJKUI Ext C block.
+    (0x2A700..0x2B734),
+    #222 characters from the CJKUI Ext D block.
+    (0x2B740..0x2B81D),
+  ]
+
+  CJKC_MIN = 0x3400
+
+  def cjks
+    cjk_a = []
+    self.each_codepoint.with_index do |cp, i|
+      next if cp < CJKC_MIN
+      cjk_a << self[i]  if CJKC_RANGES.any? {|range| range.member? cp }
+    end
+    cjk_a
+  end
+
   def align position, length
     self.__send__ position, length - cjks.size
   end
   alias_method :left, :ljust
   alias_method :right, :rjust
-
-  def cjks
-    self.scan /\p{Han}|\p{Katakana}|\p{Hiragana}\p{Hangul}/
-  end
 
   def width
     size + cjks.size

--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -1,13 +1,13 @@
 
 module Terminal
   class Table
-    
+
     attr_reader :title
     attr_reader :headings
-    
+
     ##
     # Generates a ASCII table with the given _options_.
-  
+
     def initialize options = {}, &block
       @column_widths = []
       self.style = options.fetch :style, {}
@@ -16,10 +16,10 @@ module Terminal
       self.title = options.fetch :title, nil
       yield_or_eval(&block) if block
     end
-    
+
     ##
     # Align column _n_ to the given _alignment_ of :center, :left, or :right.
-    
+
     def align_column n, alignment
       r = rows
       column(n).each_with_index do |col, i|
@@ -27,10 +27,10 @@ module Terminal
         cell.alignment = alignment unless cell.alignment?
       end
     end
-    
+
     ##
-    # Add a row. 
-    
+    # Add a row.
+
     def add_row array
       row = array == :separator ? Separator.new(self) : Row.new(self, array)
       @rows << row
@@ -44,58 +44,58 @@ module Terminal
     def add_separator
       self << :separator
     end
-    
+
     def cell_spacing
       cell_padding + style.border_y.length
     end
-    
+
     def cell_padding
       style.padding_left + style.padding_right
     end
-    
+
     ##
     # Return column _n_.
-    
+
     def column n, method = :value, array = rows
-      array.map { |row| 
+      array.map { |row|
         cell = row[n]
         cell && method ? cell.__send__(method) : cell
-      }.compact 
+      }.compact
     end
-    
+
     ##
     # Return _n_ column including headings.
-    
+
     def column_with_headings n, method = :value
       column n, method, headings_with_rows
     end
-    
+
     ##
     # Return columns.
-    
+
     def columns
-      (0...number_of_columns).map { |n| column n } 
+      (0...number_of_columns).map { |n| column n }
     end
-    
+
     ##
     # Return length of column _n_.
-    
+
     def column_width n
       width = @column_widths[n] || 0
       width + additional_column_widths[n].to_i
     end
     alias length_of_column column_width # for legacy support
-    
+
     ##
     # Return total number of columns available.
-     
+
     def number_of_columns
       headings_with_rows.map { |r| r.cells.size }.max
     end
 
     ##
     # Set the headings
-    
+
     def headings= array
       @headings = Row.new(self, array)
       recalc_column_widths @headings
@@ -103,7 +103,7 @@ module Terminal
 
     ##
     # Render the table.
-  
+
     def render
       separator = Separator.new(self)
       buffer = [separator]
@@ -120,14 +120,14 @@ module Terminal
       buffer.map { |r| r.render }.join("\n")
     end
     alias :to_s :render
-    
+
     ##
     # Return rows without separator rows.
 
     def rows
       @rows.reject { |row| row.is_a? Separator }
     end
-    
+
     def rows= array
       @rows = []
       array.each { |arr| self << arr }
@@ -136,16 +136,16 @@ module Terminal
     def style=(options)
       style.apply options
     end
-    
+
     def style
       @style ||= Style.new
     end
-    
+
     def title=(title)
       @title = title
       recalc_column_widths Row.new(self, [title_cell_options])
     end
-    
+
     ##
     # Check if _other_ is equal to self. _other_ is considered equal
     # if it contains the same headings and rows.
@@ -157,11 +157,11 @@ module Terminal
     end
 
     private
-    
+
     def columns_width
       @column_widths.inject(0) { |s, i| s + i + cell_spacing } + style.border_y.length
     end
-    
+
     def additional_column_widths
       return [] if style.width.nil?
       spacing = style.width - columns_width
@@ -175,7 +175,7 @@ module Terminal
         arr
       end
     end
-    
+
     def recalc_column_widths row
       return if row.is_a? Separator
       i = 0
@@ -183,7 +183,7 @@ module Terminal
         colspan = cell.colspan
         cell_value = cell.value_for_column_width_recalc
         colspan.downto(1) do |j|
-          cell_length = cell_value.to_s.length
+          cell_length = cell_value.to_s.width
           if colspan > 1
             spacing_length = cell_spacing * (colspan - 1)
             length_in_columns = (cell_length - spacing_length)
@@ -196,14 +196,14 @@ module Terminal
         end
       end
     end
-    
+
     ##
     # Return headings combined with rows.
-    
+
     def headings_with_rows
       [@headings] + rows
     end
-    
+
     def yield_or_eval &block
       return unless block
       if block.arity > 0


### PR DESCRIPTION
some east asian characters (chiness, japanese, korean aka cjk) will occupied two char widths compared with ascii. and will lead to indent errors. this commit will consider the character set when caculate the alighnment.