### PR TITLE
Remove references to spec.opts

### DIFF
--- a/Manifest
+++ b/Manifest
@@ -12,7 +12,6 @@ lib/terminal-table/table_helper.rb
 lib/terminal-table/version.rb
 spec/cell_spec.rb
 spec/import_spec.rb
-spec/spec.opts
 spec/spec_helper.rb
 spec/table_spec.rb
 tasks/docs.rake

--- a/terminal-table.gemspec
+++ b/terminal-table.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.description = %q{Simple, feature rich ascii table generation library}
   s.email = %q{tj@vision-media.ca}
   s.extra_rdoc_files = ["README.rdoc", "lib/terminal-table.rb", "lib/terminal-table/cell.rb", "lib/terminal-table/import.rb", "lib/terminal-table/table.rb", "lib/terminal-table/table_helper.rb", "lib/terminal-table/version.rb", "tasks/docs.rake", "tasks/gemspec.rake", "tasks/spec.rake"]
-  s.files = ["History.rdoc", "Manifest", "README.rdoc", "Rakefile", "Todo.rdoc", "examples/examples.rb", "lib/terminal-table.rb", "lib/terminal-table/cell.rb", "lib/terminal-table/import.rb", "lib/terminal-table/table.rb", "lib/terminal-table/table_helper.rb", "lib/terminal-table/version.rb", "spec/cell_spec.rb", "spec/import_spec.rb", "spec/spec.opts", "spec/spec_helper.rb", "spec/table_spec.rb", "tasks/docs.rake", "tasks/gemspec.rake", "tasks/spec.rake", "terminal-table.gemspec"]
+  s.files = ["History.rdoc", "Manifest", "README.rdoc", "Rakefile", "Todo.rdoc", "examples/examples.rb", "lib/terminal-table.rb", "lib/terminal-table/cell.rb", "lib/terminal-table/import.rb", "lib/terminal-table/table.rb", "lib/terminal-table/table_helper.rb", "lib/terminal-table/version.rb", "spec/cell_spec.rb", "spec/import_spec.rb", "spec/spec_helper.rb", "spec/table_spec.rb", "tasks/docs.rake", "tasks/gemspec.rake", "tasks/spec.rake", "terminal-table.gemspec"]
   s.homepage = %q{http://github.com/visionmedia/terminal-table}
   s.license = %q{MIT}
   s.rdoc_options = ["--line-numbers", "--inline-source", "--title", "Terminal-table", "--main", "README.rdoc"]


### PR DESCRIPTION
Very simple fix to resolve the following.

```
terminal-table at /home/jlecuirot/.rvm/gems/ruby-2.1.3@asp/bundler/gems/terminal-table-cb87f9872f65 did not have a valid gemspec.
This prevents bundler from installing bins or native extensions, but that may not affect its functionality.
The validation message from Rubygems was:
  ["spec/spec.opts"] are not files
```