### PR TITLE
add all_separators style option

### DIFF
--- a/lib/terminal-table/style.rb
+++ b/lib/terminal-table/style.rb
@@ -27,7 +27,8 @@ module Terminal
         :border_x => "-", :border_y => "|", :border_i => "+",
         :padding_left => 1, :padding_right => 1,
         :margin_left => '',
-        :width => nil, :alignment => nil
+        :width => nil, :alignment => nil,
+        :all_separators => false
       }
 
       attr_accessor :border_x
@@ -41,6 +42,8 @@ module Terminal
 
       attr_accessor :width
       attr_accessor :alignment
+
+      attr_accessor :all_separators
 
 
       def initialize options = {}

--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -121,8 +121,12 @@ module Terminal
           buffer << separator
         end
       end
-      buffer += @rows
-      buffer << separator
+      if style.all_separators
+        buffer += @rows.product([separator]).flatten
+      else
+        buffer += @rows
+        buffer << separator
+      end
       buffer.map { |r| style.margin_left + r.render }.join("\n")
     end
     alias :to_s :render

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -571,5 +571,25 @@ module Terminal
  c     7  8  9 
       EOF
     end
+
+    it "should render a table with all separators" do
+      @table.style = {:all_separators => true}
+      @table.headings = ['name', { :value => 'values', :alignment => :right, :colspan => 3}]
+      @table.headings = ['name', { :value => 'values', :colspan => 3}]
+      @table.rows = [['a', 1, 2, 3], ['b', 4, 5, 6], ['c', 7, 8, 9]]
+
+      @table.render.should == <<-EOF.deindent
+        +------+---+---+---+
+        | name | values    |
+        +------+---+---+---+
+        | a    | 1 | 2 | 3 |
+        +------+---+---+---+
+        | b    | 4 | 5 | 6 |
+        +------+---+---+---+
+        | c    | 7 | 8 | 9 |
+        +------+---+---+---+
+      EOF
+    end
+
   end
 end


### PR DESCRIPTION
This makes it a lot easier to add separators to all rows, especially when passing rows during instantiation, where looping through `add_row` is more difficult.