### PR TITLE
add #empty? to the table so you can query it directly

### DIFF
--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -155,6 +155,11 @@ module Terminal
       recalc_column_widths Row.new(self, [title_cell_options])
     end
 
+    # a table is empty if its rows have no useful content (separators aside)
+    def empty?
+      rows.empty?
+    end
+
     ##
     # Check if _other_ is equal to self. _other_ is considered equal
     # if it contains the same headings and rows.

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -591,5 +591,27 @@ module Terminal
       EOF
     end
 
+    describe "#empty?" do
+      it "should return true if there are rows" do
+        @table.empty?.should == true
+      end
+
+      it "should return true if there are just separator rows" do
+        @table << :separator
+        @table << :separator
+        @table.empty?.should == true
+      end
+
+      it "should return true if there are headers set but no rows" do
+        @table.headings = ["Header 1", "Header 2"]
+        @table.empty?.should == true
+      end
+
+      it "should return false if there are non-separator rows" do
+        @table << ["a", "b"]
+        @table << :separator
+        @table.empty?.should == false
+      end
+    end
   end
 end


### PR DESCRIPTION
Sometimes in your code you create tables in one place and output them in another:
```
table = Terminal::Table.new :title => "Cheatsheet", :headings => ['Word', 'Number']
# also populate rows (or not) here
```

And then somewhere else you have to output the table:
```
puts table
```

Which, in case the table is empty (= contains no rows), will still print the title and headings, making the output noisy while printing no useful information.

You can open the code, find that Terminal::Table has #rows, and change our puts statement to

```
puts table unless table.rows.empty?
```

But now you rely on the fact that table has rows accessible and (depending on how strictly you treat your code) violate the law of demeter. 

This little PR adds the convenience / sugar Table#empty? method that returns true if the rows array is empty (separators excluded) so you can decide whether to output the table with a simple

```
puts table unless table.empty?
```

Just a little addition to the awesome gem.