### PR TITLE
Correct Style class name in README

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -190,7 +190,7 @@ And change styles on the fly:
   
 To change the default style options:
 
-  Terminal::Style.defaults = {:width => 80}
+  Terminal::Table::Style.defaults = {:width => 80}
 
 All Table objects created afterwards will inherit these defaults.
 


### PR DESCRIPTION
Using the existing name was giving me `uninitialized constant Terminal::Style (NameError)`; changing this to use the name in this commit resolved this error.