### PR TITLE
Fix two spec failures.

### DIFF
--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -126,7 +126,7 @@ module Terminal
         buffer += @rows
         buffer << separator
       end
-      buffer.map { |r| style.margin_left + r.render }.join("\n")
+      buffer.map { |r| style.margin_left + r.render.rstrip }.join("\n")
     end
     alias :to_s :render
 


### PR DESCRIPTION
Fix these failures by striping tailing spaces of each row.

```
  3) Terminal::Table should render a table with only X cell borders
     Failure/Error: EOF

       expected: "---------------\n name  values\n---------------\n a     1  2  3\n b     4  5  6\n c     7  8  9\n---------------"
            got: "---------------\n name  values  \n---------------\n a     1  2  3 \n b     4  5  6 \n c     7  8  9 \n---------------" (using ==)
       Diff:

       @@ -1,8 +1,8 @@
        ---------------
       - name  values
       + name  values  
        ---------------
       - a     1  2  3
       - b     4  5  6
       - c     7  8  9
       + a     1  2  3 
       + b     4  5  6 
       + c     7  8  9 
        ---------------
     # ./spec/table_spec.rb:555:in `block (2 levels) in <module:Terminal>'

  4) Terminal::Table should render a table without cell borders
     Failure/Error: EOF

       expected: "\n name  values\n\n a     1  2  3\n b     4  5  6\n c     7  8  9\n"
            got: "\n name  values  \n\n a     1  2  3 \n b     4  5  6 \n c     7  8  9 \n" (using ==)
       Diff:

       @@ -1,7 +1,7 @@
        
       - name  values
       + name  values  
        
       - a     1  2  3
       - b     4  5  6
       - c     7  8  9
       + a     1  2  3 
       + b     4  5  6 
       + c     7  8  9 
     # ./spec/table_spec.rb:572:in `block (2 levels) in <module:Terminal>'
```