### PR TITLE
Fix column selection with colspan option.

### DIFF
--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -57,7 +57,15 @@ module Terminal
 
     def column n, method = :value, array = rows
       array.map { |row|
-        cell = row[n]
+        # for each cells in a row, find the column with index
+        # just greater than the required one, and go back one.
+        index = col = 0
+        row.cells.each do |cell|
+          break if index > n
+          index += cell.colspan
+          col += 1
+        end
+        cell = row[col - 1]
         cell && method ? cell.__send__(method) : cell
       }.compact
     end


### PR DESCRIPTION
Fix another spec failure.

```
  1) Terminal::Table should account for the colspan when selecting columns
     Failure/Error: @table.column_with_headings(1).should == [2,"4,5"]

       expected: [2, "4,5"]
            got: [2, 6] (using ==)
     # ./spec/table_spec.rb:30:in `block (2 levels) in <module:Terminal>'
```