### PR TITLE
Use >= 1.1.1 of unicode-display_width gem

### DIFF
--- a/lib/terminal-table/version.rb
+++ b/lib/terminal-table/version.rb
@@ -1,5 +1,5 @@
 module Terminal
   class Table
-    VERSION = '1.7.0'
+    VERSION = '1.7.1'
   end
 end

--- a/terminal-table.gemspec
+++ b/terminal-table.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "term-ansicolor"
   spec.add_development_dependency "pry"
 
-  spec.add_runtime_dependency "unicode-display_width", "~> 1.1"
+  spec.add_runtime_dependency "unicode-display_width", "~> 1.1.1"
 end


### PR DESCRIPTION
This is required to be able to use Terminal Table in a Signal trap

Fixes #77 