### PR TITLE
Use the older way of converting to hash

### DIFF
--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -245,7 +245,7 @@ module Terminal
           end
 
           # sort reversely and store it back.
-          dp[colspan][index] = rmap.sort.reverse.to_h
+          dp[colspan][index] = Hash[rmap.sort.reverse]
         end
       end
 


### PR DESCRIPTION
In the latest version of this gem, [`.to_h`](https://github.com/tj/terminal-table/pull/76/files#diff-cc6d95e7d0426a8ffc4fb8ecbc218270R248) was used to convert to Hashes from Array of arrays. This method was implemented in ruby version 2.1 and above. Since this is [a legacy gem](https://github.com/tj/terminal-table/issues/79#issuecomment-246843609), we should use a method that goes [way back](http://ruby-doc.org/core-1.9.3/Hash.html#method-c-5B-5D).

This PR fixes the issue for those who use this gem in applications that don't support ruby 2.1 yet. Also, if this gem is installed via brew in MacOS, it breaks coz brew uses [ruby 2.0.0](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/utils/ruby.sh#L32)