### PR TITLE
Fix RSpec raise_error warning

### DIFF
--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -20,7 +20,7 @@ describe Terminal::Table do
     @cell.alignment = :left
     @cell.alignment = :right
     @cell.alignment = :center
-    lambda { @cell.alignment = "foo" }.should raise_error
+    lambda { @cell.alignment = "foo" }.should raise_error(RuntimeError)
   end
 
   it "should allow multiline content" do


### PR DESCRIPTION
```
WARNING: Using the `raise_error` matcher without providing a specific error or message risks false positives, since `raise_error` will match when Ruby raises a `NoMethodError`, `NameError` or `ArgumentError`, potentially allowing the expectation to pass without even executing the method you are intending to call. Actual error raised was #<RuntimeError: Aligment must be one of: left center right>. Instead consider providing a specific error class or message. This message can be suppressed by setting: `RSpec::Expectations.configuration.on_potential_false_positives
```