### PR TITLE
Add styles to disable top and bottom borders

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -23,7 +23,7 @@ To generate a table, provide an array of arrays (which are interpreted as rows):
   rows << ['Two', 2]
   rows << ['Three', 3]
   table = Terminal::Table.new :rows => rows
-  
+
   # > puts table
   #
   # +-------+---+
@@ -51,7 +51,7 @@ Adding rows one by one:
   end
 
 To add separators between rows:
-  
+
   table = Terminal::Table.new do |t|
     t << ['One', 1]
     t << :separator
@@ -59,7 +59,7 @@ To add separators between rows:
     t.add_separator
     t.add_row ['Three', 3]
   end
-  
+
   # > puts table
   #
   # +-------+---+
@@ -71,7 +71,7 @@ To add separators between rows:
   # +-------+---+
 
 Cells can handle multiline content:
-  
+
   table = Terminal::Table.new do |t|
     t << ['One', 1]
     t << :separator
@@ -79,7 +79,7 @@ Cells can handle multiline content:
     t.add_separator
     t.add_row ['Three', 3]
   end
-  
+
   # > puts table
   #
   # +--------+---+
@@ -96,7 +96,7 @@ Cells can handle multiline content:
 To add a head to the table:
 
   table = Terminal::Table.new :headings => ['Word', 'Number'], :rows => rows
-  
+
   # > puts table
   #
   # +-------+--------+
@@ -112,7 +112,7 @@ To add a head to the table:
 To add a title to the table:
 
   table = Terminal::Table.new :title => "Cheatsheet", :headings => ['Word', 'Number'], :rows => rows
-  
+
   # > puts table
   #
   # +------------+--------+
@@ -130,7 +130,7 @@ To add a title to the table:
 To align the second column to the right:
 
   table.align_column(1, :right)
-  
+
   # > puts table
   #
   # +-------+--------+
@@ -144,7 +144,7 @@ To align the second column to the right:
 To align an individual cell, you specify the cell value in a hash along the alignment:
 
   table << ["Four", {:value => 4.0, :alignment => :center}]
-  
+
   # > puts table
   #
   # +-------+--------+
@@ -155,13 +155,13 @@ To align an individual cell, you specify the cell value in a hash along the alig
   # | Three |      3 |
   # | Four  |  4.0   |
   # +-------+--------+
-  
+
 === Style
 
 To specify style options:
-  
+
   table = Terminal::Table.new :headings => ['Word', 'Number'], :rows => rows, :style => {:width => 80}
-  
+
   # > puts table
   #
   # +--------------------------------------+---------------------------------------+
@@ -173,9 +173,9 @@ To specify style options:
   # +--------------------------------------+---------------------------------------+
 
 And change styles on the fly:
-  
+
   table.style = {:width => 40, :padding_left => 3, :border_x => "=", :border_i => "x"}
-  
+
   # > puts table
   #
   # x====================x=================x
@@ -187,7 +187,7 @@ And change styles on the fly:
   # |   Two              |   2             |
   # |   Three            |   3             |
   # x====================x=================x
-  
+
 You can also use styles to add a separator after every row:
 
   table = Terminal::Table.new do |t|
@@ -206,7 +206,22 @@ You can also use styles to add a separator after every row:
   # +---+-------+
   # | 3 | Three |
   # +---+-------+
-  
+
+You can also use styles to disable top and bottom borders of the table
+
+  table = Terminal::Table.new do |t|
+    t.headings = ['id', 'name']
+    t.rows = [[1, 'One'], [2, 'Two'], [3, 'Three']]
+    t.style = { :border_top => false, :border_bottom => false }
+  end
+
+  # > puts table
+  # | id | name  |
+  # +----+-------+
+  # | 1  | One   |
+  # | 2  | Two   |
+  # | 3  | Three |
+
 To change the default style options:
 
   Terminal::Table::Style.defaults = {:width => 80}

--- a/lib/terminal-table/style.rb
+++ b/lib/terminal-table/style.rb
@@ -24,6 +24,7 @@ module Terminal
     class Style
       @@defaults = {
         :border_x => "-", :border_y => "|", :border_i => "+",
+        :border_top => true, :border_bottom => true,
         :padding_left => 1, :padding_right => 1,
         :margin_left => '',
         :width => nil, :alignment => nil,
@@ -33,6 +34,8 @@ module Terminal
       attr_accessor :border_x
       attr_accessor :border_y
       attr_accessor :border_i
+      attr_accessor :border_top
+      attr_accessor :border_bottom
 
       attr_accessor :padding_left
       attr_accessor :padding_right

--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -122,7 +122,7 @@ module Terminal
 
     def render
       separator = Separator.new(self)
-      buffer = [separator]
+      buffer = style.border_top ? [separator] : []
       unless @title.nil?
         buffer << Row.new(self, [title_cell_options])
         buffer << separator
@@ -137,7 +137,7 @@ module Terminal
         buffer += @rows.product([separator]).flatten
       else
         buffer += @rows
-        buffer << separator
+        buffer << separator if style.border_bottom
       end
       buffer.map { |r| style.margin_left + r.render.rstrip }.join("\n")
     end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -637,5 +637,33 @@ module Terminal
         +---------+------------+--------+----------+
       EOF
     end
+
+    it "should allow to not generate top border" do
+      @table.style = { :border_top => false }
+      @table.headings = ['name', 'value']
+      @table.rows = [['a', 1], ['b', 2], ['c', 3]]
+      @table.render.should == <<-EOF.deindent
+        | name | value |
+        +------+-------+
+        | a    | 1     |
+        | b    | 2     |
+        | c    | 3     |
+        +------+-------+
+      EOF
+    end
+
+    it "should allow to not generate bottom border" do
+      @table.style = { :border_bottom => false }
+      @table.headings = ['name', 'value']
+      @table.rows = [['a', 1], ['b', 2], ['c', 3]]
+      @table.render.should == <<-EOF.deindent
+        +------+-------+
+        | name | value |
+        +------+-------+
+        | a    | 1     |
+        | b    | 2     |
+        | c    | 3     |
+      EOF
+    end
   end
 end


### PR DESCRIPTION
Sometimes table has to omit top and bottom borders.
The pull request does just that - adds a possibility to disable the borders
from being rendered.
