### PR TITLE
Allow unicode-display_width beyond 1.1.x

### DIFF
--- a/terminal-table.gemspec
+++ b/terminal-table.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "term-ansicolor"
   spec.add_development_dependency "pry"
 
-  spec.add_runtime_dependency "unicode-display_width", "~> 1.1.1"
+  spec.add_runtime_dependency "unicode-display_width", ["~> 1.1", ">= 1.1.1"]
 end


### PR DESCRIPTION
Due to #78, terminal-table now won't use `unicode-display_with` version 1.2.1. This pull requests loosens that dependency again, while avoiding versions below 1.1.1.