### PR TITLE
Table: Protect against nil in rows/column loop

### DIFF
--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -29,6 +29,7 @@ module Terminal
       r = rows
       column(n).each_with_index do |col, i|
         cell = r[i][n]
+        next unless cell
         cell.alignment = alignment unless cell.alignment?
       end
     end


### PR DESCRIPTION
This PR avoids a NoMethodError, which plagued me on 1.7.3:

Output of a failed usage:

```
/Users/olle/.gem/ruby/2.4.0/gems/terminal-table-1.7.3/lib/terminal-table/table.rb:32:in `block in align_column': undefined method `alignment?' for nil:NilClass (NoMethodError)
	from /Users/olle/.gem/ruby/2.4.0/gems/terminal-table-1.7.3/lib/terminal-table/table.rb:30:in `each'
	from /Users/olle/.gem/ruby/2.4.0/gems/terminal-table-1.7.3/lib/terminal-table/table.rb:30:in `each_with_index'
	from /Users/olle/.gem/ruby/2.4.0/gems/terminal-table-1.7.3/lib/terminal-table/table.rb:30:in `align_column'
	from /Users/olle/.gem/ruby/2.4.0/gems/fukuzatsu-2.3.1/lib/fukuzatsu/formatters/text.rb:36:in `export'
	from /Users/olle/.gem/ruby/2.4.0/gems/fukuzatsu-2.3.1/lib/fukuzatsu/parser.rb:24:in `block in report'
	from /Users/olle/.gem/ruby/2.4.0/gems/fukuzatsu-2.3.1/lib/fukuzatsu/parser.rb:23:in `each'
	from /Users/olle/.gem/ruby/2.4.0/gems/fukuzatsu-2.3.1/lib/fukuzatsu/parser.rb:23:in `report'
	from /Users/olle/.gem/ruby/2.4.0/gems/fukuzatsu-2.3.1/lib/fukuzatsu/cli.rb:22:in `check'
	from /Users/olle/.gem/ruby/2.4.0/gems/thor-0.19.4/lib/thor/command.rb:27:in `run'
	from /Users/olle/.gem/ruby/2.4.0/gems/thor-0.19.4/lib/thor/invocation.rb:126:in `invoke_command'
	from /Users/olle/.gem/ruby/2.4.0/gems/thor-0.19.4/lib/thor.rb:369:in `dispatch'
	from /Users/olle/.gem/ruby/2.4.0/gems/thor-0.19.4/lib/thor/base.rb:444:in `start'
	from /Users/olle/.gem/ruby/2.4.0/gems/fukuzatsu-2.3.1/bin/fuku:3:in `<top (required)>'
```

Skipping on when the `cell` is nil would avoid this.