### PR TITLE
Use unicode-display_width without String ext

### DIFF
--- a/lib/terminal-table/cell.rb
+++ b/lib/terminal-table/cell.rb
@@ -1,4 +1,4 @@
-require 'unicode/display_width'
+require 'unicode/display_width/no_string_ext'
 
 module Terminal
   class Table

--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -1,4 +1,4 @@
-require 'unicode/display_width'
+require 'unicode/display_width/no_string_ext'
 
 module Terminal
   class Table


### PR DESCRIPTION
Requires `unicode-display_width` without the `String` [extensions](https://github.com/janlelis/unicode-display_width/blob/master/lib/unicode/display_width/string_ext.rb) . (A `grep` shows them to be unused by this library).

This option was [introduced](https://github.com/janlelis/unicode-display_width/blob/master/CHANGELOG.md#100) in the 1.0.0 release, so is fully compatible with the current `>= 1.1.1` requirement.

This resolves issues where code can be unintentionally coupled to `terminal-table` by making use of these extensions, as well potentially conflicting with other libraries that may wish to extend String differently using the same method names.