### PR TITLE
Support unicode-display_width v2.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     terminal-table (3.0.0)
-      unicode-display_width (~> 1.1, >= 1.1.1)
+      unicode-display_width (>= 1.1.1, < 3)
 
 GEM
   remote: https://rubygems.org/
@@ -30,7 +30,7 @@ GEM
     term-ansicolor (1.7.1)
       tins (~> 1.0)
     tins (1.0.1)
-    unicode-display_width (1.7.0)
+    unicode-display_width (2.0.0)
 
 PLATFORMS
   ruby

--- a/lib/terminal-table/cell.rb
+++ b/lib/terminal-table/cell.rb
@@ -1,4 +1,4 @@
-require 'unicode/display_width/no_string_ext'
+require 'unicode/display_width'
 
 module Terminal
   class Table

--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -1,4 +1,4 @@
-require 'unicode/display_width/no_string_ext'
+require 'unicode/display_width'
 
 module Terminal
   class Table

--- a/terminal-table.gemspec
+++ b/terminal-table.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "term-ansicolor"
   spec.add_development_dependency "pry"
 
-  spec.add_runtime_dependency "unicode-display_width", ["~> 1.1", ">= 1.1.1"]
+  spec.add_runtime_dependency "unicode-display_width", [">= 1.1.1", "< 3"]
 end


### PR DESCRIPTION
Follow-up to https://github.com/tj/terminal-table/pull/104#issuecomment-718902322

Adds support for `unicode-display_width` v2.0.0, and makes it the reference version in `Gemfile.lock`. Reverts the `require` incantations to remove warnings when using v2.

cc @nateberkopec
