### PR TITLE
fixing issue #118

### DIFF
--- a/examples/issue118.rb
+++ b/examples/issue118.rb
@@ -1,0 +1,36 @@
+#!/usr/bin/env ruby
+
+require_relative '../lib/terminal-table'
+
+puts Terminal::Table.new(headings: ['a', 'b', 'c', 'd'], style: { border: :unicode })
+
+puts
+
+tbl = Terminal::Table.new do |t|
+  t.style = { border: :unicode }
+  t.add_separator
+  t.add_separator
+  t.add_row ['x','y','z']
+  t.add_separator
+  t.add_separator
+end
+puts tbl
+
+puts
+
+puts Terminal::Table.new(headings: [['a', 'b', 'c', 'd'], ['cat','dog','frog','mouse']], style: { border: :unicode })
+
+puts
+
+puts Terminal::Table.new(headings: ['a', 'b', 'c', 'd'])
+
+puts
+
+tbl = Terminal::Table.new do |t|
+  t.add_separator
+  t.add_separator
+  t.add_row ['x','y','z']
+  t.add_separator
+  t.add_separator
+end
+puts tbl

--- a/lib/terminal-table/cell.rb
+++ b/lib/terminal-table/cell.rb
@@ -81,6 +81,14 @@ module Terminal
         end
         inner_width + padding
       end
+
+      def inspect
+        fields = %i[alignment colspan index value width].map do |name|
+          val = self.instance_variable_get('@'+name.to_s)
+          "@#{name}=#{val.inspect}"
+        end.join(', ')
+        return "#<#{self.class} #{fields}>"
+      end
     end
   end
 end

--- a/lib/terminal-table/row.rb
+++ b/lib/terminal-table/row.rb
@@ -12,7 +12,7 @@ module Terminal
       ##
       # Initialize with _width_ and _options_.
 
-      def initialize table, array = []
+      def initialize table, array = [], **_kwargs
         @cell_index = 0
         @table = table
         @cells = []

--- a/spec/unicode_table_spec.rb
+++ b/spec/unicode_table_spec.rb
@@ -756,8 +756,8 @@ module Terminal
         ╰──────┴───────╯
       EOF
      end
-
-        it "should test many separator borders" do
+    
+    it "should test many separator borders" do
       @table.style = { border: :unicode_thick_edge }
       @table.title = 'Borders'
       @table.headings = ['name', 'value']
@@ -786,26 +786,66 @@ module Terminal
         ┃ name │ value ┃
         ┣══════╪═══════┫
         ┃ 1st  │ 1     ┃
-        ┣━━━━━━┿━━━━━━━┫
-        ┣╍╍╍╍╍╍┿╍╍╍╍╍╍╍┫
-        ┣┅┅┅┅┅┅┿┅┅┅┅┅┅┅┫
-        ┣┉┉┉┉┉┉┿┉┉┉┉┉┉┉┫
-        ┣━━━━━━┿━━━━━━━┫
-        ┣╍╍╍╍╍╍┿╍╍╍╍╍╍╍┫
-        ┣┅┅┅┅┅┅┿┅┅┅┅┅┅┅┫
-        ┣┉┉┉┉┉┉┿┉┉┉┉┉┉┉┫
-        ┣━━━━━━┿━━━━━━━┫
-        ┣╍╍╍╍╍╍┿╍╍╍╍╍╍╍┫
-        ┣┅┅┅┅┅┅┿┅┅┅┅┅┅┅┫
-        ┣┉┉┉┉┉┉┿┉┉┉┉┉┉┉┫
-        ┠╌╌╌╌╌╌┼╌╌╌╌╌╌╌┨
-        ┠┄┄┄┄┄┄┼┄┄┄┄┄┄┄┨
-        ┠┈┈┈┈┈┈┼┈┈┈┈┈┈┈┨
-        ┣══════╪═══════┫
+        ┣━━━━━━┷━━━━━━━┫
+        ┣╍╍╍╍╍╍╍╍╍╍╍╍╍╍┫
+        ┣┅┅┅┅┅┅┅┅┅┅┅┅┅┅┫
+        ┣┉┉┉┉┉┉┉┉┉┉┉┉┉┉┫
+        ┣━━━━━━━━━━━━━━┫
+        ┣╍╍╍╍╍╍╍╍╍╍╍╍╍╍┫
+        ┣┅┅┅┅┅┅┅┅┅┅┅┅┅┅┫
+        ┣┉┉┉┉┉┉┉┉┉┉┉┉┉┉┫
+        ┣━━━━━━━━━━━━━━┫
+        ┣╍╍╍╍╍╍╍╍╍╍╍╍╍╍┫
+        ┣┅┅┅┅┅┅┅┅┅┅┅┅┅┅┫
+        ┣┉┉┉┉┉┉┉┉┉┉┉┉┉┉┫
+        ┠╌╌╌╌╌╌╌╌╌╌╌╌╌╌┨
+        ┠┄┄┄┄┄┄┄┄┄┄┄┄┄┄┨
+        ┠┈┈┈┈┈┈┈┈┈┈┈┈┈┈┨
+        ┣══════╤═══════┫
         ┃ last │ N     ┃
         ┗━━━━━━┷━━━━━━━┛
       EOF
-     end
+    end
+    
+    it "should allow headings with no rows (issue #118.a)" do
+      @table.headings = ['a', 'b', 'c', 'd']
+      @table.render.should eq <<-EOF.deindent
+       ┌───┬───┬───┬───┐
+       │ a │ b │ c │ d │
+       ╞═══╧═══╧═══╧═══╡
+       └───────────────┘
+      EOF
+    end
+    
+    it "should allow multiple headings with no rows (issue #118.b)" do
+      @table.headings = [['a', 'b', 'c', 'd'], ['cat','dog','frog','mouse']]
+      @table.render.should eq <<-EOF.deindent
+       ┌─────┬─────┬──────┬───────┐
+       │ a   │ b   │ c    │ d     │
+       ╞═════╪═════╪══════╪═══════╡
+       │ cat │ dog │ frog │ mouse │
+       ╞═════╧═════╧══════╧═══════╡
+       └──────────────────────────┘
+      EOF
+    end
 
+    it "should not create spurrious vertical intersections for adjacent separators (issue #118.c)" do
+      @table.add_separator
+      @table.add_separator
+      @table.add_row ['x','y','z']
+      @table.add_separator
+      @table.add_separator
+      @table.render.should eq <<-EOF.deindent
+       ┌───────────┐
+       ├───────────┤
+       ├───┬───┬───┤
+       │ x │ y │ z │
+       ├───┴───┴───┤
+       ├───────────┤
+       └───────────┘
+       EOF
+    end
+
+    
   end
 end


### PR DESCRIPTION
While this was previously undefined behavior, it did appear a bug crept in due to adding keywords to the Separator - which inherits from Row, and row captured all arguments into an Array (versus grabbing the **kwargs) and accidentally created bogus Cell objects.

In any event, I think this is doing the right thing now and there are some tests for it.