### PR TITLE
fix align_column for nil values and colspan

### DIFF
--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -27,10 +27,8 @@ module Terminal
     # Align column _n_ to the given _alignment_ of :center, :left, or :right.
 
     def align_column n, alignment
-      r = rows
-      column(n).each_with_index do |col, i|
-        cell = r[i][n]
-        next unless cell
+      # nil forces the column method to return the cell itself
+      column(n, nil).each do |cell|
         cell.alignment = alignment unless cell.alignment?
       end
     end

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -355,17 +355,41 @@ module Terminal
 
     it "should align columns, but allow specifics to remain" do
       @table.headings = ['Just some characters', 'Num']
-      @table.rows = [[{:value => 'a', :alignment => :left}, 1], ['b', 2], ['c', 3]]
+      @table.rows = [[nil, 0], [{:value => 'a', :alignment => :left}, nil], ['b', 2], ['c', 3]]
       @table.align_column 0, :center
       @table.align_column 1, :right
       @table.render.should eq <<-EOF.deindent
         +----------------------+-----+
         | Just some characters | Num |
         +----------------------+-----+
-        | a                    |   1 |
+        |                      |   0 |
+        | a                    |     |
         |          b           |   2 |
         |          c           |   3 |
         +----------------------+-----+
+      EOF
+    end
+
+    it "should align columns taking colspan into account" do
+      @table.headings = ['xxx'] * 4
+      @table.rows = [
+        [1, 2, 3, 4],
+        [5, {:value => 6, :colspan => 2}, 7],
+        [{:value => 8, :colspan => 2}, 9, :a],
+        [{:value => :b, :colspan => 2}, {:value => :c, :colspan => 2}],
+        [{:value => :d, :colspan => 3}, :e],
+      ]
+      @table.align_column 3, :right
+      @table.render.should eq <<-EOF.deindent
+        +-----+-----+-----+-----+
+        | xxx | xxx | xxx | xxx |
+        +-----+-----+-----+-----+
+        | 1   | 2   | 3   |   4 |
+        | 5   | 6         |   7 |
+        | 8         | 9   |   a |
+        | b         |         c |
+        | d               |   e |
+        +-----------------+-----+
       EOF
     end
 


### PR DESCRIPTION
I've noticed the problem for table containing nil values:

```ruby
$stdout << Terminal::Table.new(headings: %w[xxx xxx]) do
  add_row [nil, 1]
  add_row [2, 3]
  add_row [4, 5]
  align_column 0, :right
end
```

doesn't change the alignment for the cell with 4:

```
+-----+-----+
| xxx | xxx |
+-----+-----+
|     | 1   |
|   2 | 3   |
| 4   | 5   |
+-----+-----+
```

The `align_method` internally uses `column` which without second argument returns a list of non null values at specific column taking colspan into account. But afterwards the value is ignored and cells are fetched by index, which doesn't work well if there are cells with custom colspan in the table:

```ruby
$stdout << Terminal::Table.new(headings: %w[xxx] * 4) do
  add_row [1, 2, 3, 4]
  add_row [5, {:value => 6, :colspan => 2}, 7]
  add_row [{:value => 8, :colspan => 2}, 9, :a]
  add_row [{:value => :b, :colspan => 2}, {:value => :c, :colspan => 2}]
  add_row [{:value => :d, :colspan => 3}, :e]
  align_column 1, :right
end
```

prints:

```
+-----+-----+-----+-----+
| xxx | xxx | xxx | xxx |
+-----+-----+-----+-----+
| 1   |   2 | 3   | 4   |
| 5   |         6 | 7   |
| 8         |   9 | a   |
| b         |         c |
| d               |   e |
+-----------------+-----+
```