### PR TITLE
Add Ruby 3.0 and 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
       matrix:
         os: [ubuntu]
-        ruby: [2.4, 2.5, 2.6, 2.7]
+        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1]
 
     runs-on: ${{ matrix.os }}-latest
 


### PR DESCRIPTION
This PR adds Ruby 3.0 and 3.1 to the CI matrix.

Everything runs green on my fork.