### PR TITLE
Add support for 'header_separator' option for Style

### DIFF
--- a/lib/terminal-table/style.rb
+++ b/lib/terminal-table/style.rb
@@ -227,11 +227,13 @@ module Terminal
       def border_bottom=(val) ; @border.bottom = val ; end
       def border_left=(val) ; @border.left = val ; end
       def border_right=(val) ; @border.right = val ; end
+      def header_separator=(val) ; @header_separator = val ; end
 
       def border_top ; @border.top ; end
       def border_bottom ; @border.bottom ; end
       def border_left ; @border.left ; end
       def border_right ; @border.right ; end
+      def header_separator ; @header_separator ; end
 
 
       attr_accessor :padding_left

--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -14,7 +14,10 @@ module Terminal
       @headings = []
       @rows = []
       @column_widths = []
-      self.style = options.fetch :style, {}
+      style_opts = options.fetch :style, {}
+      style_opts[:header_separator] = true unless style_opts.key?(:header_separator)
+
+      self.style = style_opts
       self.headings = options.fetch :headings, []
       self.rows = options.fetch :rows, []
       self.title = options.fetch :title, nil
@@ -133,7 +136,9 @@ module Terminal
       @headings.each do |row|
         unless row.cells.empty?
           buffer << row
-          buffer << Separator.new(self, border_type: :double, implicit: true)
+          if style.header_separator
+            buffer << Separator.new(self, border_type: :double, implicit: true)
+          end
         end
       end
       if style.all_separators


### PR DESCRIPTION
- modified:   lib/terminal-table/style.rb
    - add support for the header_separator option
        - true  => print a separator between the header and the first row
        - false => do not print the separator
- modified:   lib/terminal-table/table.rb
    - add support for the header_separator option for the style object
    - default to true unless user specifies it to be false