### PR TITLE
Update unicode-display_width dependency

### DIFF
--- a/terminal-table.gemspec
+++ b/terminal-table.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "term-ansicolor"
   spec.add_development_dependency "pry"
 
-  spec.add_runtime_dependency "unicode-display_width", [">= 1.1.1", "< 3"]
+  spec.add_runtime_dependency "unicode-display_width", [">= 2.4.2", "< 3"]
 end


### PR DESCRIPTION
Version 2.4.2 provides significant performance improvements

See [CHANGELOG](https://github.com/janlelis/unicode-display_width/blob/main/CHANGELOG.md#242) for details.

However, it introduces Ruby 2.4 as the minimum required Ruby version.