### PR TITLE
Replace non unicode characters to avoid crashes

### DIFF
--- a/lib/terminal-table/cell.rb
+++ b/lib/terminal-table/cell.rb
@@ -48,7 +48,7 @@ module Terminal
         val.public_send(positions[position], length)
       end
       def lines
-        @value.to_s.split(/\n/)
+        @value.to_s.encode("utf-8", invalid: :replace).split(/\n/)
       end
 
       ##

--- a/spec/table_spec.rb
+++ b/spec/table_spec.rb
@@ -120,6 +120,18 @@ module Terminal
       EOF
     end
 
+    it "should replace illegal unicode characters" do
+      @table.headings = ["\xAE"]
+      @table << ['a']
+      @table.render.should eq <<-EOF.deindent
+        +---+
+        | � |
+        +---+
+        | a |
+        +---+
+      EOF
+    end
+
     it "should render styles properly" do
       @table.headings = ['Char', 'Num']
       @table.style = {


### PR DESCRIPTION
This was encountered in https://github.com/fastlane/fastlane/issues/21852

Without this, `Terminal::Table.new` can crash with

```
..............F.......................................

Failures:

  1) Terminal::Table should replace illegal unicode characters
     Failure/Error: @value.to_s.split(/\n/)
     
     ArgumentError:
       invalid byte sequence in UTF-8
     # ./lib/terminal-table/cell.rb:51:in `split'
     # ./lib/terminal-table/cell.rb:51:in `lines'
     # ./lib/terminal-table/cell.rb:71:in `value_for_column_width_recalc'
     # ./lib/terminal-table/table.rb:233:in `block (2 levels) in recalc_column_widths'
     # ./lib/terminal-table/table.rb:232:in `each'
     # ./lib/terminal-table/table.rb:232:in `block in recalc_column_widths'
     # ./lib/terminal-table/table.rb:230:in `each'
     # ./lib/terminal-table/table.rb:230:in `recalc_column_widths'
     # ./lib/terminal-table/table.rb:368:in `column_widths'
     # ./lib/terminal-table/table.rb:97:in `column_width'
     # ./lib/terminal-table/separator.rb:33:in `block in render'
     # ./lib/terminal-table/separator.rb:32:in `each'
     # ./lib/terminal-table/separator.rb:32:in `render'
     # ./lib/terminal-table/table.rb:171:in `block in render'
     # ./lib/terminal-table/table.rb:171:in `map'
     # ./lib/terminal-table/table.rb:171:in `render'
     # ./spec/table_spec.rb:126:in `block (2 levels) in <module:Terminal>'

Finished in 0.0141 seconds (files took 0.07159 seconds to load)
54 examples, 1 failure
```
