### PR TITLE
CI: Add Ruby 3.3, 3.4 - and trust setup-ruby to bundle install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,12 +12,12 @@ jobs:
 
       matrix:
         os: [ubuntu]
-        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3]
+        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3, 3.4]
 
     runs-on: ${{ matrix.os }}-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
 
       matrix:
         os: [ubuntu]
-        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2]
+        ruby: [2.4, 2.5, 2.6, 2.7, '3.0', 3.1, 3.2, 3.3]
 
     runs-on: ${{ matrix.os }}-latest
 
@@ -24,5 +24,4 @@ jobs:
           bundler-cache: true
           ruby-version: ${{ matrix.ruby }}
 
-      - run: bundle install
       - run: bundle exec rspec


### PR DESCRIPTION
This PR extends the CI build matrix.

It also stops repeating `bundle install`, after setup-ruby has done its installation using cached Bundler gems.