### PR TITLE
Allows setting headings to nil

### DIFF
--- a/lib/terminal-table/table.rb
+++ b/lib/terminal-table/table.rb
@@ -109,6 +109,8 @@ module Terminal
     # Set the headings
 
     def headings= arrays
+      return if arrays.nil?
+  
       arrays = [arrays] unless arrays.first.is_a?(Array)
       @headings = arrays.map do |array|
         row = Row.new(self, array)


### PR DESCRIPTION
Just skips the whole initialization of headings

here is what i was doing:

```
    def table(data)
      is_hashes = data.first.from_deep_struct.is_a?(Hash)
      headings = is_hashes ? data.first.to_h.keys : nil
      rows = is_hashes ? data.map(&:values) : data.map { |row| wrap(row) }
      puts Terminal::Table.new(headings: headings, rows: rows)
    end
```