### PR TITLE
Relax gem version requirement for `unicode-display_width`

### DIFF
--- a/terminal-table.gemspec
+++ b/terminal-table.gemspec
@@ -22,5 +22,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "term-ansicolor"
   spec.add_development_dependency "pry"
 
-  spec.add_runtime_dependency "unicode-display_width", [">= 1.1.1", "< 3"]
+  spec.add_runtime_dependency "unicode-display_width", [">= 1.1.1", "< 4"]
 end


### PR DESCRIPTION
Resolves https://github.com/tj/terminal-table/issues/138

I think this is harmless ... bundled with 2.x version, specs passed; relaxed gemspec, bumped bundle, ran specs again ... seems ok?